### PR TITLE
add support for setuptools.build_meta backend

### DIFF
--- a/pyproject2setuppy/main.py
+++ b/pyproject2setuppy/main.py
@@ -7,11 +7,13 @@ import toml
 
 import pyproject2setuppy.flit
 import pyproject2setuppy.poetry
+import pyproject2setuppy.setuptools
 
 
 MODULES = (
     pyproject2setuppy.flit,
     pyproject2setuppy.poetry,
+    pyproject2setuppy.setuptools,
 )
 
 

--- a/pyproject2setuppy/setuptools.py
+++ b/pyproject2setuppy/setuptools.py
@@ -1,0 +1,30 @@
+# pyproject2setup.py -- setuptools support
+# vim:se fileencoding=utf-8 :
+# (c) 2020 Eli Schwartz
+# 2-clause BSD license
+
+import os
+import sys
+
+
+def handle_setuptools(data):
+    """
+    Handle pyproject.toml unserialized into data, by ignoring it and using the
+    setuptools build system instead.
+
+    Prefer running the contents of setup.py, but fall back to running a setup()
+    function.
+    """
+    if os.path.exists('setup.py'):
+        os.execv(sys.executable, ['pyproject2setuppy', 'setup.py'] + sys.argv[1:])
+    else:
+        from setuptools import setup
+        setup()
+
+
+def get_handlers():
+    """
+    Return build-backend mapping for setuptools.
+    """
+
+    return {'setuptools.build_meta': handle_setuptools}


### PR DESCRIPTION
This is expected to just call setuptools on its own. But it needs to be special cased, since setup.py does not need to exist, and if it does, it needs to be invoked directly.