### PR TITLE
Normalize project name before autodecting matching packages

### DIFF
--- a/pyproject2setuppy/poetry.py
+++ b/pyproject2setuppy/poetry.py
@@ -11,8 +11,17 @@ from collections import defaultdict
 
 import email.utils
 import os.path
+import re
 
 from pyproject2setuppy.common import auto_find_packages
+
+
+def normalize_package_name(name):
+    """
+    Normalize project name to package name.
+    https://github.com/python-poetry/poetry-core/blob/1.0.0/poetry/core/utils/helpers.py#L27
+    """
+    return re.sub('[-_]+', '_', name).replace('.', '_').lower()
 
 
 def handle_poetry(data):
@@ -31,7 +40,9 @@ def handle_poetry(data):
         author_emails.append(addr)
 
     if 'packages' not in metadata:
-        package_args = auto_find_packages(metadata['name'])
+        package_args = auto_find_packages(
+                normalize_package_name(metadata['name'])
+        )
     else:
         package_args = {'packages': [], 'package_dir': {}}
         for p in metadata['packages']:

--- a/tests/test_poetry.py
+++ b/tests/test_poetry.py
@@ -44,6 +44,7 @@ license = "MIT"
         'test_package/__init__.py',
         'other_package/__init__.py',
         'nested_package/__init__.py',
+        'test_special_chars_package/__init__.py',
         'nested_package/subpackage/__init__.py',
         'nested_package/subpackage/subsub/__init__.py',
         'src/subdir_package/__init__.py',
@@ -313,3 +314,16 @@ class PoetryPluginsAndScriptsTest(unittest.TestCase, PoetryTestCase):
             ]
         }
     }
+
+
+class PoetryNormalizedProjectNameTest(unittest.TestCase, PoetryTestCase):
+    """
+    Test normalizing package names.
+    """
+    def setUp(self):
+        self.expected_base['name'] = 'Test__special.chars--package'
+        self.toml_base = self.toml_base.replace(
+                'name = "test_package"',
+                'name = "{}"'.format(self.expected_base['name'])
+        )
+        self.expected_base['packages'] = ['test_special_chars_package']


### PR DESCRIPTION
Without this, package `foo_bar` from a project named `foo-bar` was not detected.

Real-life example: the `hypothesis_auto` package from https://github.com/timothycrosley/hypothesis-auto/blob/master/pyproject.toml
```toml
[tool.poetry]
name = "hypothesis-auto"
[…]
```